### PR TITLE
updates case typo

### DIFF
--- a/src/shareModal/ShareModal.jsx
+++ b/src/shareModal/ShareModal.jsx
@@ -39,7 +39,7 @@ import litInputCss from '../reusableComponents/litInput/LitInput.css';
 import litDevModeCss from '../shareModal/devMode/DevModeContent.css';
 import litFooterCss from '../reusableComponents/litFooter/LitFooter.css';
 import litBackButtonCss from '../reusableComponents/litFooter/LitBackButton.css';
-import litNextButtonCss from '../reusableComponents/litFooter/litNextButton.css';
+import litNextButtonCss from '../reusableComponents/litFooter/LitNextButton.css';
 import litConfirmationModalCss from '../reusableComponents/litConfirmationModal/LitConfirmationModal.css';
 import litDeleteModalCss from '../reusableComponents/litDeleteModal/LitDeleteModal.css';
 import litMultipleAddConditionCss from './multipleConditionSelect/MultipleAddCondition.css';


### PR DESCRIPTION
doesnt build on Linux without this. If this is not fixed, a Nextjs (TS) builder throws

```
SyntaxError: Unexpected token '}'
    at compileFunction (<anonymous>)
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1033:15)
    at Module._compile (node:internal/modules/cjs/loader:1069:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.lit-share-modal-v3 (/home/stadolf/work/project/.next/server/pages/some-page.js:42:18) {
  page: '/some-page'
}
```
(quite confusing, yes.)
